### PR TITLE
Spring Boot starter not necessary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,5 @@ dependencies {
 	compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.1.3.RELEASE'
 	implementation('io.springfox:springfox-swagger2:2.9.2')
 	implementation('io.springfox:springfox-swagger-ui:2.9.2')
-	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }


### PR DESCRIPTION
It's going to get pulled from the spring-boot-starter-web